### PR TITLE
Styles the rawgit button to look like the github "raw" button

### DIFF
--- a/app/scripts/rawgit.js
+++ b/app/scripts/rawgit.js
@@ -26,6 +26,8 @@ function createRawGitButton(matchingElement) {
   // This seems to be enough to get the button to look like the standard GitHub buttons.
   rawGitElement.classList.add('minibutton');
   rawGitElement.classList.add(RAWGIT_BUTTON_CLASS);
+  rawGitElement.classList.add('btn');
+  rawGitElement.classList.add('btn-sm');
   rawGitElement.textContent = 'RawGit';
   rawGitElement.setAttribute('aria-label', 'View on RawGit');
   rawGitElement.href = massageUrlString(matchingElement.href);


### PR DESCRIPTION
Adding the two classes `btn` and `btn-sm` to the rawgit `href` element will make it align to the other github buttons shown in the web interface when you view a file such as "Raw" , "View". It will also be styled with the same properties instead of a normal mis-aligned link. This PR does exactly that.
